### PR TITLE
Fix function gen-client-final-message and add util function parse-server-signature

### DIFF
--- a/src/packages.lisp
+++ b/src/packages.lisp
@@ -12,4 +12,5 @@
             #:gen-sasl-password
             #:parse-server-nonce
             #:parse-server-salt
-            #:parse-server-iterations))
+            #:parse-server-iterations
+            #:parse-server-signature))

--- a/src/scram.lisp
+++ b/src/scram.lisp
@@ -108,3 +108,9 @@
   (parse-integer (cdr (assoc "i"
                              (parse-server-response :response response)
                              :test #'equal))))
+
+(defun parse-server-signature (&key response)
+  (check-type response string)
+  (cdr (assoc "v"
+              (parse-server-response :response response)
+              :test #'equal)))

--- a/src/scram.lisp
+++ b/src/scram.lisp
@@ -11,48 +11,60 @@
   ((text :initarg :text :reader text)))
 
 (defun gen-client-final-message
-    (&key password client-nonce client-initial-message server-response)
+    (&key username password client-nonce client-initial-message server-response)
+  "Takes a password, the initial client nonce, the initial client message & the server response.
+   Generates the final client message, and returns it along with the server signature."
   (check-type client-nonce string)
   (check-type client-initial-message string)
   (check-type server-response string)
+  (check-type username string)
   (check-type password string)
-  "Takes a password, the initial client nonce, the initial client message & the server response.
-   Generates the final client message, and returns it along with the server signature."
-  (if (eq nil (parse-server-nonce :nonce client-nonce :response server-response))
-      (error 'unexpected-nonce :text "The server nonce does not begin with the client nonce."))
-  (let* ((final-message-bare (format nil "c=biws,r=~a" (parse-server-nonce :nonce client-nonce
-                                                                           :response server-response)))
+  (when (eq nil (parse-server-nonce :nonce client-nonce :response server-response))
+    (error 'unexpected-nonce :text "The server nonce does not begin with the client nonce."))
+  (let* ((final-message-bare (format nil "c=biws,r=~a"
+                                     (parse-server-nonce :nonce client-nonce
+                                                         :response server-response)))
+         (hashed-password (ironclad:digest-sequence :md5
+                                                    (ironclad:ascii-string-to-byte-array
+                                                     (format nil "~A:mongo:~A"
+                                                             username
+                                                             password))))
          (salted-password    (ironclad:pbkdf2-hash-password
-                               (ironclad:ascii-string-to-byte-array password)
-                               :salt       (ironclad:ascii-string-to-byte-array
-                                           (parse-server-salt :response server-response))
-                               :digest     :sha1
-                               :iterations (parse-server-iterations :response server-response)))
+                              (ironclad:ascii-string-to-byte-array
+                               (ironclad:byte-array-to-hex-string
+                                hashed-password))
+                              :salt       (parse-server-salt :response server-response)
+                              :digest     :sha1
+                              :iterations (parse-server-iterations :response server-response)))
          (client-key         (gen-hmac-digest :key salted-password
-                                              :message (ironclad:ascii-string-to-byte-array "Client Key")))
+                                              :message (ironclad:ascii-string-to-byte-array
+                                                        "Client Key")))
          (stored-key         (gen-sha1-digest :key client-key))
          (auth-message       (format nil "~a,~a,~a"
-                                     (if (= 0 (search "n,," client-initial-message))
+                                     (if (equal 0 (search "n,," client-initial-message))
                                          (subseq client-initial-message 3)
-                                         (format nil "~a" client-initial-message))
+                                         client-initial-message)
                                      server-response
                                      final-message-bare))
          (client-signature   (gen-hmac-digest :key stored-key
-                                              :message (ironclad:ascii-string-to-byte-array auth-message)))
+                                              :message (ironclad:ascii-string-to-byte-array
+                                                        auth-message)))
          (client-proof       (ironclad:integer-to-octets
-                               (logxor (ironclad:octets-to-integer client-key)
-                                       (ironclad:octets-to-integer client-signature))))
+                              (logxor (ironclad:octets-to-integer client-key)
+                                      (ironclad:octets-to-integer client-signature))))
          (server-key         (gen-hmac-digest :key salted-password
-                                              :message (ironclad:ascii-string-to-byte-array "Server Key")))
+                                              :message (ironclad:ascii-string-to-byte-array
+                                                        "Server Key")))
          (server-signature   (gen-hmac-digest :key server-key
-                                              :message (ironclad:ascii-string-to-byte-array auth-message)))
+                                              :message (ironclad:ascii-string-to-byte-array
+                                                        auth-message)))
          (final-message      (format nil "~a,p=~a"
                                      final-message-bare
                                      (base64-encode-octets client-proof))))
     (pairlis '(final-message
                server-signature)
-              (list final-message
-                    (base64-encode-octets server-signature)))))
+             (list final-message
+                   (base64-encode-octets server-signature)))))
 
 (defun gen-client-encoded-initial-message (&key username nonce)
   (check-type username string)
@@ -86,13 +98,13 @@
 (defun parse-server-salt (&key response)
   (check-type response string)
   "Gets the base64-decoded salt from the base64-decoded response string."
-  (base64-decode (cdr (assoc "s"
-                             (parse-server-response :response response)
-                             :test #'equal))))
+  (base64:base64-string-to-usb8-array (cdr (assoc "s"
+                                                  (parse-server-response :response response)
+                                                  :test #'equal))))
 
 (defun parse-server-iterations (&key response)
   (check-type response string)
   "Gets the number of iterations from the base64-decoded response string."
   (parse-integer (cdr (assoc "i"
-                      (parse-server-response :response response)
-                      :test #'equal))))
+                             (parse-server-response :response response)
+                             :test #'equal))))


### PR DESCRIPTION
Finally get SCRAM-SHA-1 auth work on my fork [cl-mongo](https://github.com/muyinliu/cl-mongo) with cl-scram.

Thanks.